### PR TITLE
Fixed custom reduction postprocess bug when reduction target is a future

### DIFF
--- a/charmpy/charmlib_cython.pyx
+++ b/charmpy/charmlib_cython.pyx
@@ -632,7 +632,9 @@ class CharmLib(object):
           msg.advance(buf_size)
       elif b"custom_reducer" in header:
         reducer = getattr(charm.reducers, header[b"custom_reducer"])
-        if reducer.hasPostprocess: args[0] = reducer.postprocess(args[0])
+        # reduction result won't always be in position 0, but will always be last
+        # (e.g. if reduction target is a future, the reduction result will be 2nd argument)
+        if reducer.hasPostprocess: args[-1] = reducer.postprocess(args[-1])
 
     return header, args
 

--- a/charmpy/charmpy.py
+++ b/charmpy/charmpy.py
@@ -340,7 +340,9 @@ class Charm(object):
           rel_offset += size
       elif b"custom_reducer" in header:
         reducer = getattr(self.reducers, header[b"custom_reducer"])
-        if reducer.hasPostprocess: args[0] = reducer.postprocess(args[0])
+        # reduction result won't always be in position 0, but will always be last
+        # (e.g. if reduction target is a future, the reduction result will be 2nd argument)
+        if reducer.hasPostprocess: args[-1] = reducer.postprocess(args[-1])
 
     return header, args
 

--- a/tests/reductions/test_gather.py
+++ b/tests/reductions/test_gather.py
@@ -6,7 +6,7 @@ class Main(Chare):
   def __init__(self, args):
 
     self.recvdReductions = 0
-    self.expectedReductions = 4
+    self.expectedReductions = 5
 
     ro.nDims = 1
     ro.ARRAY_SIZE = [10] * ro.nDims
@@ -21,6 +21,9 @@ class Main(Chare):
     ro.grpProxy = Group(TestGroup)
     ro.arrProxy.doGather()
     ro.grpProxy.doGather()
+    red_future = charm.createFuture()
+    ro.arrProxy.doGather(red_future)
+    self.done_gather_single(red_future.get())
 
   def done_gather_single(self, result):
     gather_arr_indices = list(range(self.nElements))
@@ -44,11 +47,14 @@ class Test(Chare):
   def __init__(self):
     print("Test " + str(self.thisIndex) + " created on PE " + str(CkMyPe()))
 
-  def doGather(self):
-    # gather single elements
-    self.gather(self.thisIndex[0], ro.mainProxy.done_gather_single)
-    # gather arrays
-    self.gather(self.thisIndex, ro.mainProxy.done_gather_array)
+  def doGather(self, red_future=None):
+    if red_future is None:
+      # gather single elements
+      self.gather(self.thisIndex[0], ro.mainProxy.done_gather_single)
+      # gather arrays
+      self.gather(self.thisIndex, ro.mainProxy.done_gather_array)
+    else:
+      self.gather(self.thisIndex[0], red_future)
 
 class TestGroup(Chare):
   def __init__(self):


### PR DESCRIPTION
When a future is the reduction target, the final call to an entry
method to deliver the result will have 2 arguments: the future ID,
and the reduction result. So, the reducer's postprocess function
has to be called on the 2nd argument (not the first).