### PR TITLE
Remove Chare.gather() method to free name for use as entry method

### DIFF
--- a/charmpy/chare.py
+++ b/charmpy/chare.py
@@ -112,9 +112,6 @@ class Chare(object):
     def contribute(self, data, reducer_type, target):
         charm.contribute(data, reducer_type, target, self)
 
-    def gather(self, data, target):
-        charm.contribute(data, Reducer.gather, target, self)
-
     def AtSync(self):
         # NOTE this will fail if called from a chare that is not in an array (as it should be)
         charm.CkArraySend(self.thisProxy.aid, self.thisIndex, self.thisProxy.AtSync.ep, (b'', []))
@@ -132,12 +129,12 @@ class Chare(object):
 method_restrictions = {
     # reserved methods are those that can't be redefined in user subclass
     'reserved': {'__addLocal__', '__removeLocal__', '__flush_wait_queues__',
-                 '__waitEnqueue__', 'wait', 'contribute', 'gather', 'AtSync',
+                 '__waitEnqueue__', 'wait', 'contribute', 'AtSync',
                  'migrate', '_future_deposit_result'},
 
     # these methods of Chare cannot be entry methods. NOTE that any methods starting
     # and ending with '__' are automatically excluded from being entry methods
-    'non_entry_method': {'wait', 'contribute', 'gather', 'AtSync', 'migrate'}
+    'non_entry_method': {'wait', 'contribute', 'AtSync', 'migrate'}
 }
 
 # ----------------- Mainchare and Proxy -----------------

--- a/tests/dcopy/test_dcopy.py
+++ b/tests/dcopy/test_dcopy.py
@@ -1,5 +1,5 @@
 import charmpy
-from charmpy import charm, Chare, Array
+from charmpy import charm, Chare, Array, Reducer
 from charmpy import readonlies as ro
 import time
 import array
@@ -48,7 +48,7 @@ class Test(Chare):
 
         self.msgsRcvd = 0
 
-        self.gather(charm.myPe(), self.thisProxy.recvLocations)
+        self.contribute(charm.myPe(), Reducer.gather, self.thisProxy.recvLocations)
 
     def recvLocations(self, locations):
         loc = defaultdict(list)

--- a/tests/migration/test_migrate.py
+++ b/tests/migration/test_migrate.py
@@ -1,4 +1,4 @@
-from charmpy import charm, Chare, Group, Array
+from charmpy import charm, Chare, Group, Array, Reducer
 from charmpy import readonlies as ro
 import numpy
 import math
@@ -30,7 +30,7 @@ class Test(Chare):
         self.originalPe = charm.myPe()
         self.data = numpy.arange(100, dtype='int64') * (self.originalPe + 1)
         # notify controllers that array elements are created and pass home PE of every element
-        self.gather(charm.myPe(), ro.controllers.arrayElemsCreated)
+        self.contribute(charm.myPe(), Reducer.gather, ro.controllers.arrayElemsCreated)
 
     def start(self):
         if self.thisIndex == (0,) and self.iteration % 20 == 0: print("Iteration " + str(self.iteration))

--- a/tests/reductions/test_gather.py
+++ b/tests/reductions/test_gather.py
@@ -50,11 +50,11 @@ class Test(Chare):
   def doGather(self, red_future=None):
     if red_future is None:
       # gather single elements
-      self.gather(self.thisIndex[0], ro.mainProxy.done_gather_single)
+      self.contribute(self.thisIndex[0], Reducer.gather, ro.mainProxy.done_gather_single)
       # gather arrays
-      self.gather(self.thisIndex, ro.mainProxy.done_gather_array)
+      self.contribute(self.thisIndex, Reducer.gather, ro.mainProxy.done_gather_array)
     else:
-      self.gather(self.thisIndex[0], red_future)
+      self.contribute(self.thisIndex[0], Reducer.gather, red_future)
 
 class TestGroup(Chare):
   def __init__(self):
@@ -62,9 +62,9 @@ class TestGroup(Chare):
 
   def doGather(self):
     # gather single elements
-    self.gather(self.thisIndex, ro.mainProxy.done_gather_single)
+    self.contribute(self.thisIndex, Reducer.gather, ro.mainProxy.done_gather_single)
     # gather arrays
-    self.gather([self.thisIndex, 42], ro.mainProxy.done_gather_array)
+    self.contribute([self.thisIndex, 42], Reducer.gather, ro.mainProxy.done_gather_array)
 
 
 charm.start(Main)

--- a/tests/thread_entry_methods/test1.py
+++ b/tests/thread_entry_methods/test1.py
@@ -1,4 +1,4 @@
-from charmpy import charm, Chare, Array, Group, threaded
+from charmpy import charm, Chare, Array, Group, threaded, Reducer
 from charmpy import readonlies as ro
 import time
 
@@ -12,7 +12,7 @@ class Test(Chare):
 
     def __init__(self):
         # gather list of PEs on which each array element is located and broadcast to every member
-        self.gather(charm.myPe(), self.thisProxy.start)
+        self.contribute(charm.myPe(), Reducer.gather, self.thisProxy.start)
 
     @threaded
     def start(self, pes):

--- a/tests/thread_entry_methods/test1_when.py
+++ b/tests/thread_entry_methods/test1_when.py
@@ -1,4 +1,4 @@
-from charmpy import charm, Chare, Array, Group, threaded, when
+from charmpy import charm, Chare, Array, Group, threaded, when, Reducer
 from charmpy import readonlies as ro
 import time
 
@@ -14,7 +14,7 @@ class Test(Chare):
         self.iteration = 0
         self.msgsRcvd = 0
         # gather list of PEs on which each array element is located and broadcast to every member
-        self.gather(charm.myPe(), self.thisProxy.start)
+        self.contribute(charm.myPe(), Reducer.gather, self.thisProxy.start)
 
     @threaded
     def start(self, pes):


### PR DESCRIPTION
Chare.gather() is a convenience method, but prevents the 'gather'
name from being used by developers.

Instead, gather should be called by doing:
self.contribute(data, Reducer.gather, target)