### PR TITLE
Allow some methods of charm object to be remotely callable

### DIFF
--- a/test_config.json
+++ b/test_config.json
@@ -1,6 +1,10 @@
 [
     {
         "force_min_processes": 4,
+        "path": "tests/charm_remote.py"
+    },
+    {
+        "force_min_processes": 4,
         "path": "tests/array_maps/test1.py"
     },
     {

--- a/tests/array_maps/test1.py
+++ b/tests/array_maps/test1.py
@@ -16,10 +16,7 @@ class MyChare(Chare):
 
     def __init__(self, last):
         assert charm.myPe() == index_to_pe(self.thisIndex), "ArrayMap failed"
-        if last: self.contribute(None, None, self.thisProxy.done)
-
-    def done(self):
-        exit()
+        if last: self.contribute(None, None, charm.thisProxy[0].exit)
 
 
 def main(args):

--- a/tests/charm_remote.py
+++ b/tests/charm_remote.py
@@ -1,0 +1,30 @@
+from charmpy import charm, Chare, Group, threaded
+import random
+
+
+class Controller(Chare):
+
+    @threaded
+    def start(self):
+        # print('Controller running on PE', charm.myPe())
+        for i in range(charm.numPes()):
+            assert i == charm.thisProxy[i].myPe(ret=True).get()
+
+        g = Group(Test)
+
+
+class Test(Chare):
+
+    def __init__(self):
+        self.contribute(None, None, charm.thisProxy[0].exit)
+
+
+def main(args):
+    if charm.numPes() > 1:
+        pes = list(range(1, charm.numPes()))
+    else:
+        pes = [0]
+    Chare(Controller, onPE=random.choice(pes)).start()
+
+
+charm.start(main)

--- a/tests/migration/chare_migration.py
+++ b/tests/migration/chare_migration.py
@@ -22,10 +22,7 @@ class Migrate(Chare):
         if self.thisIndex == (0,):
             print("Test called on PE ", charm.myPe())
         assert charm.myPe() == self.toPe
-        self.contribute(None, None, self.thisProxy[0].done)
-
-    def done(self):
-        exit()
+        self.contribute(None, None, charm.thisProxy[0].exit)
 
     def start(self):
         """

--- a/tests/migration/test_migrate.py
+++ b/tests/migration/test_migrate.py
@@ -18,9 +18,6 @@ class Controller(Chare):
         for i in range(len(home_pes)): arrayElemHomeMap[i] = home_pes[i]
         self.contribute(None, None, ro.array.start)
 
-    def done(self):
-        exit()
-
 
 class Test(Chare):
 
@@ -40,7 +37,7 @@ class Test(Chare):
         for i in range(work): A += 1.33
         self.iteration += 1
         if self.iteration == MAX_ITER:
-            self.contribute(None, None, ro.controllers[0].done)
+            self.contribute(None, None, charm.thisProxy[0].exit)
         elif self.iteration % 20 == 0:
             self.AtSync()
         else:


### PR DESCRIPTION
The charm object is present in every process and represents the
Charm4py runtime. This patch effectively turns it into a chare, by
creating a Group of CharmRemote objects which act as an interface
to the charm object in every process. The new chare can be
accessed via the 'thisProxy' attribute of 'charm'.